### PR TITLE
corrections to allow braille conversion

### DIFF
--- a/ptx/hmwk-1-1.xml
+++ b/ptx/hmwk-1-1.xml
@@ -464,7 +464,7 @@
     <li>Add <m>15\degree</m> to Ridgecrest's temperature to find Sunnyvale's temperature.</li>
     <li>Temperature in Sunnyvale <m>=</m> Temperature in Ridgecrest <m>+15</m></li>
     <li><m>S=R+15</m></li>
-    <li><p><!--<image source="photos/hp-1-1-9ans.png"/>-->
+    <li><p><!--<image source="photos/hp-1-1-9ans.png"/>--></p>
     <image xml:id="hp-1-1-9ans" width="50%">
         <description>line</description>
         <latex-image>
@@ -486,7 +486,7 @@
         \end{tikzpicture}]]>
     </latex-image>
     </image>
-    </p></li>
+    </li>
 </ol></p></answer></exercise>
 
 <exercise number="10"><statement><p>Jerome is driving from his home in White Falls to his parents' home in Castle Heights, 200 miles away. Fill in the table.</p>
@@ -620,7 +620,7 @@
         <li>Divide the total bill by 3 to get Milton's share.</li>
         <li>Milton's share <m>= \dfrac{\text{total bill}}{3}</m></li>
         <li><m>s=\dfrac{b}{3}</m></li>
-        <li><p><!--<image source="photos/hp-1-1-11ans.png"/>-->
+        <li><p><!--<image source="photos/hp-1-1-11ans.png"/>--></p>
     <image xml:id="hp-1-1-11ans" width="50%"><description>line</description><latex-image>
         <![CDATA[
         \begin{tikzpicture} [xscale=.04, yscale=0.1]
@@ -639,7 +639,7 @@
          }
         \end{tikzpicture}]]>
     </latex-image>
-    </image></p></li>
+    </image></li>
     </ol></p></answer></exercise>
 
 <exercise number="12"><statement><p>Nutrition experts tell us that no more than 30% of the calories we consume should come from fat. Fill in the table with the fat calories allowed daily for various calorie levels.</p>

--- a/ptx/hmwk-2-3.xml
+++ b/ptx/hmwk-2-3.xml
@@ -181,7 +181,7 @@
     <li>Graph your equation on the grid.</li></ol></p></introduction>
 
 <exercise number="6"><statement><p>Greta's math notebook has 100 pages, and she uses on average 6 pages per day for notes and homework.  How many pages, <m>P</m>, will she have left after <m>d</m> days?</p>
-<sidebyside><tabular top="major" halign="center" right="minor" left="minor" bottom="minor">              
+<table><tabular top="major" halign="center" right="minor" left="minor" bottom="minor">
                     <row bottom="minor">
                         <cell><m>d</m></cell>
                         <cell><m>0</m></cell>
@@ -196,7 +196,7 @@
                         <cell><m>\hphantom{0000}</m></cell>
                         <cell><m>\hphantom{0000}</m></cell>
                         <cell><m>\hphantom{0000}</m></cell></row>
-                    </tabular></sidebyside>
+                    </tabular></table>
     <sidebyside width="50%"><!--<image source="photos/hp-2-3-6.png"><description>grid</description></image>-->
     <image xml:id="hp-2-3-6">
         <description>grid</description>
@@ -281,7 +281,7 @@
                         <cell><m>220</m></cell>
                         <cell><m>240</m></cell></row>
                     </tabular></sidebyside></li>
-        <li><p><sidebyside width="50%" margins="0% 50%">
+        <li><sidebyside width="50%" margins="0% 50%">
     <image xml:id="hp-2-3-7ans">
         <description>graph</description>
         <latex-image>
@@ -307,7 +307,7 @@
         %\filldraw[blue] (\x, {200+\x/5}) circle (2.5cm);
         \end{tikzpicture}]]>
     </latex-image>
-    </image></sidebyside></p></li></ol></p></answer></exercise>
+    </image></sidebyside></li></ol></p></answer></exercise>
 </exercisegroup>
 
 <exercise number="8"><statement><p>Darren inherited some money and has been spending it at the rate of $100 per day. Right now he has $2000 left.<ol marker="a.">
@@ -361,7 +361,7 @@
 	<li>What was Darren's balance 15 days ago?</li>
 	<li>When will Darren's balance reach $500?</li></ol></p></statement></exercise>
 
-<exercise number="9"><statement><p>Gregory purchased stereo equipment on a monthly installment plan. After <m>m</m> months, Gregory still owes a balance of <m>B</m> dollars.
+<exercise number="9"><statement><p>Gregory purchased stereo equipment on a monthly installment plan. After <m>m</m> months, Gregory still owes a balance of <m>B</m> dollars.</p>
 	<sidebyside width="40%"><!--<image source="photos/hp-2-3-9.png"><description>grid</description></image>-->
     <image xml:id="hp-2-3-9">
         <description>line on grid</description>
@@ -393,7 +393,7 @@
 	<li>How much does Gregory pay each month?</li>
 	<li>How much does Gregory owe after 6 months?</li>
 	<li>How many monthly payments will Gregory make?</li>
-	<li>Write an algebraic equation for <m>B</m> in terms of <m>m</m>.</li></ol></p></statement>
+	<li>Write an algebraic equation for <m>B</m> in terms of <m>m</m>.</li></ol></statement>
 <answer><p><ol>
     <li><p>$5400</p></li>
     <li><p>$30</p></li>
@@ -619,7 +619,7 @@
 </sidebyside></answer></exercise>
 </exercisegroup>
 
-<exercise number="16"><statement><p>The graph of <m>y=2x+6</m> is shown below.
+<exercise number="16"><statement><p>The graph of <m>y=2x+6</m> is shown below.</p>
 	<sidebyside width="45%"><!--<image source="photos/hp-2-3-16.png"><description>grid</description></image>-->
     <image xml:id="hp-2-3-16">
         <description>line on grid</description>
@@ -642,7 +642,8 @@
         \end{tikzpicture}]]>
     </latex-image>
     </image>
-    </sidebyside>
+        </sidebyside>
+        <p>
 <ol marker="a.">	
 	<li>Use the graph to evaluate the expression <m>2x+6</m> for <m>x=-5</m>.</li>
 	<li>Find a point on the graph with <m>y=-4</m>.  What is the <m>x</m>-value of the point?</li>

--- a/ptx/hmwk-5-4.xml
+++ b/ptx/hmwk-5-4.xml
@@ -184,8 +184,8 @@
 
 <exercisegroup cols="2"><introduction><p>For Problems 31<ndash/>32, find the product without a calculator by using rectangles.  </p></introduction>
 
-<exercise number="31"><statement><p><m>36 \times 42</m>
-	<image width="60%" source="photos/hp-5-4-31"><description>rectangle</description></image></p></statement>
+<exercise number="31"><statement><p><m>36 \times 42</m></p>
+	<image width="60%" source="photos/hp-5-4-31"><description>rectangle</description></image></statement>
  <answer><m>1512</m></answer></exercise>
 
 <exercise number="32"><statement><p><m>82 \times 16</m></p>

--- a/ptx/section-1-3.xml
+++ b/ptx/section-1-3.xml
@@ -326,7 +326,7 @@ which gives Francine's age, <m>F</m>, in terms of Delbert's age, <m>D</m>. We ca
     <md><mrow>y \amp = 1.5x</mrow>
         <mrow>\downarrow \amp </mrow>
         <mrow>\alert{3.75} \amp   = 1.5x</mrow></md>
- We locate 3.75 on the <m>y</m>-axis, then find the point on the graph with <m>y</m>-coordinate 3.75. 
+ We locate 3.75 on the <m>y</m>-axis, then find the point on the graph with <m>y</m>-coordinate 3.75. </p>
     <!--<image source="photos/fig-1-3-ex5.png"/>-->
     <image xml:id="fig-1-3-ex5ans" width="50%"><description>y=1.5x</description><latex-image>
         <![CDATA[
@@ -345,7 +345,7 @@ which gives Francine's age, <m>F</m>, in terms of Delbert's age, <m>D</m>. We ca
         \draw[line width=0.8mm, cyan, dashed, dash pattern=on 9pt off 4pt] (2.5,3.75) -- (0,3.75) node[left, yshift=-2pt, text=cyan, scale=0.9] {3.75};
         \draw[cyan, fill=cyan] (2.5,3.75) circle(.75mm);
         \end{tikzpicture}]]></latex-image></image>
- The <m>x</m>-coordinate of this point is 2.5, so the ordered pair <m>(2.5, 3.75)</m> is a solution of the equation <m>y=1.5x</m>, and <m>x=2.5</m> is the solution of the equation <m>1.5x=3.75</m>.</p>
+<p> The <m>x</m>-coordinate of this point is 2.5, so the ordered pair <m>(2.5, 3.75)</m> is a solution of the equation <m>y=1.5x</m>, and <m>x=2.5</m> is the solution of the equation <m>1.5x=3.75</m>.</p>
 </solution></example>
   
 <exercise number="8"><statement><p>The graph of an equation is a picture of its <fillin characters="6"/>.</p></statement>
@@ -555,7 +555,7 @@ which gives Francine's age, <m>F</m>, in terms of Delbert's age, <m>D</m>. We ca
                         <cell><m>\hphantom{0000}</m></cell></row>
                     </tabular>
         <!--<image source="photos/act-1-3-2.png"><description>grid</description></image>-->
-        <p><image xml:id="act-1-3-2" width="80%"><description>grid</description><latex-image>
+        <image xml:id="act-1-3-2" width="80%"><description>grid</description><latex-image>
         <![CDATA[
         \begin{tikzpicture} [scale=.5]
         \draw[cyan] (0,0) grid[xstep=1, ystep=1] (12,12);
@@ -570,7 +570,7 @@ which gives Francine's age, <m>F</m>, in terms of Delbert's age, <m>D</m>. We ca
          \draw[black, thick] (.1,\y) --++(-.2,0)  node[left] {\y};
         }
         \end{tikzpicture}]]>
-        </latex-image></image></p></li>
+        </latex-image></image></li>
     </ol></p></li>
 </ol></p></activity>
 

--- a/ptx/section-2-5.xml
+++ b/ptx/section-2-5.xml
@@ -159,7 +159,7 @@ the minus sign preceding <m>(7x-4)</m> applies to each term inside the parenthes
 
 <example><statement><p>Simplify <m>~-5b-(3-2b)+(4b-6)</m></p></statement>
 
-<solution><p>Before combining like terms, we must remove the parentheses. We change the signs of any terms inside parentheses preceded by a minus sign; we do not change the signs of terms inside parentheses preceded by a plus sign.
+<solution><p>Before combining like terms, we must remove the parentheses. We change the signs of any terms inside parentheses preceded by a minus sign; we do not change the signs of terms inside parentheses preceded by a plus sign.</p>
     <!--<image source="photos/fig-2-5-ex7.png"><description>graphic</description></image>-->
     <image width="100%" xml:id="fig-2-5-ex7"><description>equations</description><latex-image>
         <!-- CDATA prevents certain LaTeX code from being interpreted as xml -->
@@ -181,7 +181,7 @@ the minus sign preceding <m>(7x-4)</m> applies to each term inside the parenthes
         \node[right] at (O2) {$=-5b+2b +4b-3-6$};
         \coordinate (O3) at (0,-1.4);
         \node[right] at (O3) {$=b-9$};
-        \end{tikzpicture}]]></latex-image></image></p></solution></example>
+        \end{tikzpicture}]]></latex-image></image></solution></example>
 
 <exercise number="5"><statement><p>We can remove parentheses that follow <fillin characters="6"/>.</p></statement>
     	<answer><p>a plus sign</p></answer></exercise>

--- a/ptx/section-3-1.xml
+++ b/ptx/section-3-1.xml
@@ -96,7 +96,7 @@ The <m>y</m>-intercept is the point <m>(0,3\dfrac{1}{2})</m>.</p>
         <mrow>3x  \amp = 7  \amp \amp  \blert{\text{Divide both sides by 3.}}</mrow>
         <mrow>x \amp = \dfrac{7}{3} = 2\dfrac{1}{3}</mrow></md>   
 The <m>x</m>-intercept is the point <m>(2\dfrac{1}{3}, 0)</m>.</p>
-<p>Here is a table showing the two intercepts. We plot the intercepts and connect them with a straight line to obtain the graph below.
+<p>Here is a table showing the two intercepts. We plot the intercepts and connect them with a straight line to obtain the graph below.</p>
 	<sidebyside widths="30% 35%" valigns="middle middle" margins="0% 20%">
         <tabular top="major" halign="center" right="minor" left="minor" bottom="minor">              
                     <row bottom="minor">
@@ -131,7 +131,7 @@ The <m>x</m>-intercept is the point <m>(2\dfrac{1}{3}, 0)</m>.</p>
         \filldraw[red!80!black] (7/3,0) circle (2mm);
         \filldraw[red!80!black] (0,7/2) circle (2mm);
         \filldraw[blue] (1,2) circle (1mm);
-        \end{tikzpicture}]]></latex-image></image></sidebyside></p>
+        \end{tikzpicture}]]></latex-image></image></sidebyside>
 <p>It is a good idea to find a third point as a check.  We choose <m>x=\alert{1}</m> and solve for <m>y</m>. 
 		<md><mrow>3 + 2(\alert{1}) \amp = 7 \amp \amp  \blert{\text{Subtract 3 from both sides.}}</mrow>
             <mrow>2y \amp = 4  \amp \amp  \blert{\text{Divide both sides by 2.}}</mrow>

--- a/ptx/section-3-4.xml
+++ b/ptx/section-3-4.xml
@@ -92,7 +92,7 @@ is said to be in <term>slope-intercept form</term>. The coefficient <m>m</m> is 
 
 <example xml:id="Example-3-4-2"><statement><p>Graph the equation <m>~y=\dfrac{3}{4}x-2</m></p></statement>
 
-<solution><p>The slope of the line is <m>\dfrac{3}{4}</m> and its <m>y</m>-intercept is the point <m>(0,-2)</m>. We begin by plotting the <m>y</m>-intercept, as shown in the figure. Next, we use the slope to find another point on the line. 
+<solution><p>The slope of the line is <m>\dfrac{3}{4}</m> and its <m>y</m>-intercept is the point <m>(0,-2)</m>. We begin by plotting the <m>y</m>-intercept, as shown in the figure. Next, we use the slope to find another point on the line. </p>
 	<!--<image source="photos/fig-3-4-ex2.png"><description>graph</description></image>-->
     <image width="50%" xml:id="ig-3-4-ex2"><description>graph of line</description><latex-image>
         <!-- CDATA prevents certain LaTeX code from being interpreted as xml -->
@@ -124,7 +124,7 @@ is said to be in <term>slope-intercept form</term>. The coefficient <m>m</m> is 
         \filldraw[red] (4,1) circle (1.5mm);
         \filldraw[red] (-4,-5) circle (1.5mm);
         \end{tikzpicture}]]></latex-image></image>
-The slope,
+<p>The slope,
 	<me>m = \dfrac{\Delta y}{\Delta x} = \dfrac{3}{4}</me>
 gives the ratio of the change in <m>y</m>-coordinate to the change in <m>x</m>-coordinate as we move from any point on the line to another. Thus, starting at the point <m>(0,-2)</m>, we move: <ul>
 	<li>3 units up (the positive <m>y</m>-direction),then</li>
@@ -515,4 +515,4 @@ All of these equations pass through the origin, so their <m>y</m>-intercepts are
 </subsection>
 
 <xi:include href="./hmwk-3-4.xml" />
-</section>  
+</section>

--- a/ptx/section-7-1.xml
+++ b/ptx/section-7-1.xml
@@ -173,7 +173,7 @@ because we have not changed the sign of <m>\alert{\text{each}}</m> term inside p
 
 <example><statement><p>Subtract <m>~2n^2-3n-2~</m> from <m>~4n^2+2n-5</m></p></statement>
 
-<solution><p><sidebyside><tabular>         
+<solution><sidebyside><tabular>
                     <row>
                         <cell><m>~~~~~~~~4n^2+2n-5</m></cell>
                         <cell><m>\hphantom{0000}</m></cell>
@@ -186,7 +186,7 @@ because we have not changed the sign of <m>\alert{\text{each}}</m> term inside p
                     	<cell><m>\hphantom{0000}</m></cell>
                     	<cell><m>\hphantom{0000}</m></cell>
                         <cell><m>~~~~~~~~~~2n^2+5n-3</m></cell></row>
-                    </tabular></sidebyside></p></solution></example>
+                    </tabular></sidebyside></solution></example>
 
 <exercise number="5"><statement><p>When subtracting two polynomials, what must we do before combining like terms?</p></statement>
     <answer><p>Change the sign of each term in the subtracted polynomial.</p></answer></exercise>

--- a/ptx/section-8-3.xml
+++ b/ptx/section-8-3.xml
@@ -204,7 +204,7 @@ The LCD is <m>x(x-2)(x+2)</m>.</p>
 <exercise number="6"><statement><p>State the four steps for adding or subtracting fractions.</p></statement>
     <answer><p>Find the LCD, build, combine, reduce.</p></answer></exercise>
 
-<problem><sttement>
+<problem><statement>
 
 <p>Simplify.</p>
 <p><ol marker="1.">
@@ -214,7 +214,7 @@ The LCD is <m>x(x-2)(x+2)</m>.</p>
 <li><m>(x-3)2x+(x+2)4</m></li>
 <li><m>x^2(x-1)-2x(x+2)</m></li>
 <li><m>3x(x-4)-2(x^2-16)-4x</m></li>
-</ol></p></sttement>
+</ol></p></statement>
 
 <answer><p><ol marker="1." cols="2">
     <li><m>-x+3</m></li>


### PR DESCRIPTION
There are a few problems with the PreTeXt source that are corrected here.  Some `sidebyside` and `image` elements were inside a `p` and `statement` was misspelled in one place.  The source now builds cleanly to braille.